### PR TITLE
charmap' codec can't decode byte 0x98 in position 877Update client.py

### DIFF
--- a/importer/client.py
+++ b/importer/client.py
@@ -90,7 +90,7 @@ class ApiClient:
 
     def create_document(self, document, is_publish):
         if os.path.isfile(document.path):
-            with open(document.path) as f:
+            with open(document.path, encoding="utf8") as f:
                 text = f.read()
         else:
             text = "# {}".format(document.title)


### PR DESCRIPTION
This PR fixes incorrect encoding when reading files that have non cp1251 encoding, for instance some complex markdown pages with symbols in it. 

Thanks for the importer, I successfully imported cheat sheet repo !  

https://github.com/ChristianLempa/cheat-sheets